### PR TITLE
Googlelayer

### DIFF
--- a/heatcanvas-googlemaps.js
+++ b/heatcanvas-googlemaps.js
@@ -31,6 +31,7 @@ function HeatCanvasOverlayView(map, options){
     this.data = [];
     var self=this;
     google.maps.event.addListener(self.map,'dragend',function(){self.draw();});
+    google.maps.event.addListener(self.map,'dblclick',function(){self.draw();});
 }
 
 HeatCanvasOverlayView.prototype = new google.maps.OverlayView();


### PR DESCRIPTION
sorry to bother you again.
After test, it seems that it will cause the heatcanvas area offset and found the reason is missed the redraw after double click.
So try to make it up by adding this event listener.
