### PR TITLE
Possible fix for clear() not working on OpenLayers instances.

### DIFF
--- a/heatcanvas-openlayers.js
+++ b/heatcanvas-openlayers.js
@@ -75,7 +75,7 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
     // override
     redraw: function() {
         this._resetCanvasPosition();
-        this.heatmap.clear();
+        this.clear();
         if (this.data.length > 0) {
             for (var i=0, l=this.data.length; i<l; i++) {
                 var lonlat = new OpenLayers.LonLat(this.data[i].lon, this.data[i].lat);


### PR DESCRIPTION
It seems that the data isn't stored in this.heatmap.data, this diff makes it clear both areas.

Not sure if this is the best fix or not.
