### PR TITLE
HeatCanvas.getPath() wasn't working when heatcanvas.js was requested via Rails asset pipeline

### DIFF
--- a/heatcanvas.js
+++ b/heatcanvas.js
@@ -193,11 +193,11 @@ HeatCanvas.getPath = function() {
     var scriptTags = document.getElementsByTagName("script");
     for (var i=0; i<scriptTags.length; i++) {
         var src = scriptTags[i].src;
-        var pos = src.indexOf("heatcanvas.js");
+        var match = src.match(/heatcanvas(-[a-z0-9]{32})?\.js/);
+        var pos = match ? match.index : 0;
         if (pos > 0) {
             return src.substring(0, pos);
         }
     }
     return "";
 }
-


### PR DESCRIPTION
Have relaxed the match on script@src to make it look for (e.g.) heatcanvas-c06aed21a4141b93c0c920171ea062bc.js as well as heatcanvas.js
