### PR TITLE
Vastly improve the Webpack build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Available via bower
 
 `bower install heatcanvas`
 
+Webpack Build
+-------------
+`npm run webpack`
+
+This will generate a build in the `/dist` folder. This includes the main `heatcanvas.js`, the `heatcanvas-worker.js`
+Web Worker script, and specific versions for 51 Maps, Baidu Maps, Google Maps, Leaflet Maps, and OpenLayers.
+
+To use, import into an HTML document using a `script` tag. The imports will be available at `HeatCanvas`,
+`HeatCanvas51Layer`, `HeatCanvasBaiduLayer`, `HeatCanvasOverlayView`, `HeatCanvasLeaflet`, and `HeatCanvasOpenLayers`
+respectively.
+
 Usage
 -----
 

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "homepage": "https://sunng87.github.io/heatcanvas",
   "devDependencies": {
     "webpack": "^3.8.1"
+  },
+  "scripts": {
+      "webpack": "webpack"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "homepage": "https://sunng87.github.io/heatcanvas",
   "devDependencies": {
+    "copy-webpack-plugin": "^4.2.0",
     "webpack": "^3.8.1"
   },
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -20,9 +20,4 @@
  * SOFTWARE.
  */
 
-var HeatCanvas = require("./heatcanvas.js");
-var HeatCanvas51Layer = require("./heatcanvas-51map");
-var HeatCanvasBaiduLayer = require("./heatcanvas-baidumap");
-var HeatCanvasOverlayView = require("./heatcanvas-googlemaps");
-var LeafletHeatcanvas = require("./heatcanvas-leaflet");
-var OpenLayersHeatcanvas = require("./heatcanvas-openlayers");
+export {default} from "./heatcanvas";

--- a/src/heatcanvas-51map.js
+++ b/src/heatcanvas-51map.js
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-var HeatCanvas = require("./heatcanvas");
+import {default as HeatCanvas} from "./heatcanvas";
 
 export default function HeatCanvas51Layer(map,options){
     options = options || {};

--- a/src/heatcanvas-baidumap.js
+++ b/src/heatcanvas-baidumap.js
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-var HeatCanvas = require("./heatcanvas");
+import {default as HeatCanvas} from "./heatcanvas";
 
 export default function HeatCanvasBaiduLayer(map,options){
     options = options || {};

--- a/src/heatcanvas-openlayers.js
+++ b/src/heatcanvas-openlayers.js
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-var HeatCanvas = require("./heatcanvas");
+import {default as HeatCanvas} from "./heatcanvas";
 
 OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
 

--- a/src/heatcanvas.js
+++ b/src/heatcanvas.js
@@ -82,7 +82,7 @@ HeatCanvas.prototype._render = function(f_value_color){
     var ctx = this.canvas.getContext("2d");
     ctx.clearRect(0, 0, this.width, this.height);
 
-    defaultColor = this.bgcolor || [0, 0, 0, 255];
+    var defaultColor = this.bgcolor || [0, 0, 0, 255];
     var canvasData = ctx.createImageData(this.width, this.height);
     for (var i=0; i<canvasData.data.length; i+=4){
         canvasData.data[i] = defaultColor[0]; // r

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,81 @@
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = {
+module.exports = [{
     entry: {
         app: "./src/app.js",
     },
     output: {
         path: __dirname + "/dist/",
-        filename: "heatcanvas.js"
+        filename: "heatcanvas.js",
+        library: "HeatCanvas",
+        libraryExport: "default"
+    },
+    devtool: 'source-map',
+    plugins: [
+        new CopyWebpackPlugin([
+            {from:'src/heatcanvas-worker.js',to:'heatcanvas-worker.js'} 
+        ]),
+    ]
+},
+{
+    entry: {
+        app: "./src/heatcanvas-51map.js"
+    },
+    output: {
+        path: __dirname + "/dist/",
+        filename: "heatcanvas-51map.js",
+        library: "HeatCanvas51Layer",
+        libraryExport: "default"
     },
     devtool: 'source-map'
-};
+},
+{
+    entry: {
+        app: "./src/heatcanvas-baidumap.js"
+    },
+    output: {
+        path: __dirname + "/dist/",
+        filename: "heatcanvas-baidumap.js",
+        library: "HeatCanvasBaiduLayer",
+        libraryExport: "default"
+    },
+    devtool: 'source-map'
+},
+{
+    entry: {
+        app: "./src/heatcanvas-googlemaps.js"
+    },
+    output: {
+        path: __dirname + "/dist/",
+        filename: "heatcanvas-googlemaps.js",
+        library: "HeatCanvasOverlayView",
+        libraryExport: "default"
+    },
+    devtool: 'source-map'
+},
+{
+    entry: {
+        app: "./src/heatcanvas-leaflet.js"
+    },
+    output: {
+        path: __dirname + "/dist/",
+        filename: "heatcanvas-leaflet.js",
+        library: "HeatCanvasLeaflet",
+        libraryExport: "default"
+    },
+    devtool: 'source-map'
+},
+{
+    entry: {
+        app: "./src/heatcanvas-openlayers.js"
+    },
+    output: {
+        path: __dirname + "/dist/",
+        filename: "heatcanvas-openlayers.js",
+        library: "HeatCanvasOpenLayers",
+        libraryExport: "default"
+    },
+    devtool: 'source-map'
+}
+];


### PR DESCRIPTION
Vastly improve the Webpack build.

Add `npm run webpack` command.

Add documentation for Webpack to README.md 

Split the different variant builds into separate webpack outputs. 

Make the library components available at variables like `HeatCanvas`.

Fix a strict mode failure (Webpack implies "use strict";)

.gitignore node_modules/
