### PR TITLE
making heatcanvas work with modern leaflet version

### DIFF
--- a/src/heatcanvas-leaflet.js
+++ b/src/heatcanvas-leaflet.js
@@ -20,13 +20,13 @@
  * SOFTWARE.
  */
 
-var HeatCanvas = require("./heatcanvas");
+import {default as HeatCanvas} from './heatcanvas.js';
 
 L.TileLayer.HeatCanvas = L.Class.extend({
 
     initialize: function(options, heatCanvasOptions){
         this.heatCanvasOptions = heatCanvasOptions;
-        this.data= [];
+        this.data = [];
         this._onRenderingStart = null;
         this._onRenderingEnd = null;
     },
@@ -52,7 +52,7 @@ L.TileLayer.HeatCanvas = L.Class.extend({
     },
 
     _initHeatCanvas: function(map, options){
-        options = options || {};                        
+        options = options || {};
         this._step = options.step || 1;
         this._degree = options.degree || HeatCanvas.LINEAR;
         this._opacity = options.opacity || 0.6;
@@ -110,7 +110,7 @@ L.TileLayer.HeatCanvas = L.Class.extend({
 
     clear: function(){
         this.heatmap.clear();
-		this.data = [];
+        this.data = [];
     },
 
     redraw: function(){

--- a/src/heatcanvas-leaflet.js
+++ b/src/heatcanvas-leaflet.js
@@ -61,17 +61,18 @@ L.TileLayer.HeatCanvas = L.Layer.extend({
         this._zIndex = options.zIndex || null;
         this._colorscheme = options.colorscheme || null;
 
+        var mapSize = this.map.getSize();
         var container = L.DomUtil.create('div', 'leaflet-heatmap-container');
         container.style.position = 'absolute';
-        container.style.width = this.map.getSize().x+"px";
-        container.style.height = this.map.getSize().y+"px";
+        container.style.width = mapSize.x+"px";
+        container.style.height = mapSize.y+"px";
         if (this._zIndex) {
             container.style.zIndex = this._zIndex;
         }
 
         var canv = document.createElement("canvas");
-        canv.width = this.map.getSize().x;
-        canv.height = this.map.getSize().y;
+        canv.width = mapSize.x;
+        canv.height = mapSize.y;
         canv.style.width = canv.width+"px";
         canv.style.height = canv.height+"px";
         canv.style.opacity = this._opacity;

--- a/src/heatcanvas-leaflet.js
+++ b/src/heatcanvas-leaflet.js
@@ -66,7 +66,7 @@ L.TileLayer.HeatCanvas = L.Layer.extend({
         container.style.position = 'absolute';
         container.style.width = mapSize.x+"px";
         container.style.height = mapSize.y+"px";
-        if (this._zIndex) {
+        if (this._zIndex != null) {
             container.style.zIndex = this._zIndex;
         }
 

--- a/src/heatcanvas-leaflet.js
+++ b/src/heatcanvas-leaflet.js
@@ -22,9 +22,11 @@
 
 import {default as HeatCanvas} from './heatcanvas.js';
 
-L.TileLayer.HeatCanvas = L.Class.extend({
+L.TileLayer.HeatCanvas = L.Layer.extend({
 
     initialize: function(options, heatCanvasOptions){
+        L.Util.setOptions(this, options);
+
         this.heatCanvasOptions = heatCanvasOptions;
         this.data = [];
         this._onRenderingStart = null;
@@ -56,12 +58,16 @@ L.TileLayer.HeatCanvas = L.Class.extend({
         this._step = options.step || 1;
         this._degree = options.degree || HeatCanvas.LINEAR;
         this._opacity = options.opacity || 0.6;
+        this._zIndex = options.zIndex || null;
         this._colorscheme = options.colorscheme || null;
 
         var container = L.DomUtil.create('div', 'leaflet-heatmap-container');
         container.style.position = 'absolute';
         container.style.width = this.map.getSize().x+"px";
         container.style.height = this.map.getSize().y+"px";
+        if (this._zIndex) {
+            container.style.zIndex = this._zIndex;
+        }
 
         var canv = document.createElement("canvas");
         canv.width = this.map.getSize().x;
@@ -109,7 +115,8 @@ L.TileLayer.HeatCanvas = L.Class.extend({
     },
 
     clear: function(){
-        this.heatmap.clear();
+        if (this.heatmap)
+	        this.heatmap.clear();
         this.data = [];
     },
 
@@ -119,8 +126,8 @@ L.TileLayer.HeatCanvas = L.Class.extend({
 
 });
 
-L.TileLayer.heatcanvas = function (options) {
-    return new L.TileLayer.HeatCanvas(options);
+L.TileLayer.heatcanvas = function (options, heatCanvasOptions) {
+    return new L.TileLayer.HeatCanvas(options, heatCanvasOptions);
 };
 
-export default L.TitleLayer.heatcanvas;
+export default L.TileLayer.heatcanvas;


### PR DESCRIPTION
Hi! 
I enjoyed using ancient version your plugin with ancient LeafLet version (0.7) for many years. 
But when i tried to migrate to actual versions of both plugin and Leaflet, it turned out they fail with several errors.

I spent some time debugging, and made it work.

Hope, this fixes issue #34, and probably even #27, and #32

Serge.