### PR TITLE
fix and migrate leaflet, google maps, openstreet maps and baidu demos

### DIFF
--- a/baidumap.html
+++ b/baidumap.html
@@ -4,17 +4,18 @@
         <meta charset="utf8" />
         <title>Baidu Heatmap</title>
 
-        <script type="text/javascript" src="http://api.map.baidu.com/api?v=1.2"></script>
-        <script type="text/javascript" src="heatcanvas.js"></script>
-        <script type="text/javascript" src="heatcanvas-baidumap.js"></script>
+        <script type="text/javascript" src="https://api.map.baidu.com/api?v=1.2"></script>
 
         <style type="text/css">
             #map{
             }
         </style>
 
-        <script type="text/javascript">
-            function init() {
+        <script type="module">
+            import {default as HeatCanvas} from './heatcanvas.js';
+            import {default as HeatCanvasBaiduLayer} from './heatcanvas-baidumap.js';
+
+            (function init() {
                 var point = new BMap.Point(116,39);
                 var map = new BMap.Map(document.getElementById("map"));
                 map.centerAndZoom(point, 6);
@@ -25,11 +26,11 @@
                   heatmap.pushData(data[i][0], data[i][1], data[i][2]);
                 }
                 map.addOverlay(heatmap);
-            }
+            })();
         </script>
     </head>
 
-    <body onload="init();">
+    <body>
         <div id="map" style="width:700px; height:500px;"></div>
     </body>
 </html>

--- a/googlemap.html
+++ b/googlemap.html
@@ -4,7 +4,7 @@
         <meta charset="utf8" />
         <title>Google Heatmap</title>
 
-        <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
+        <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false"></script>
         <script type="module" src="heatcanvas.js"></script>
         <script type="module" src="heatcanvas-googlemaps.js"></script>
 

--- a/googlemap.html
+++ b/googlemap.html
@@ -13,7 +13,7 @@
             }
         </style>
 
-        <script type="text/javascript">
+        <script type="module">
             import {default as HeatCanvas} from './heatcanvas.js';
 
             (function init() {

--- a/googlemap.html
+++ b/googlemap.html
@@ -5,8 +5,8 @@
         <title>Google Heatmap</title>
 
         <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false"></script>
-        <script type="text/javascript" src="heatcanvas.js"></script>
-        <script type="text/javascript" src="heatcanvas-googlemaps.js"></script>
+        <script type="module" src="heatcanvas.js"></script>
+        <script type="module" src="heatcanvas-googlemaps.js"></script>
 
         <style type="text/css">
             #map{
@@ -14,7 +14,9 @@
         </style>
 
         <script type="text/javascript">
-            function init() {
+            import {default as HeatCanvas} from './heatcanvas.js';
+
+            (function init() {
                 var latlng = new google.maps.LatLng(37, 104.2);
                 var myoptions = {
                     zoom: 4,
@@ -29,11 +31,11 @@
                 for(var i=0,l=data.length; i<l; i++) {
                     heatmap.pushData(data[i][0], data[i][1], data[i][2]);
                 }
-            }
+            })();
         </script>
     </head>
 
-    <body onload="init();">
+    <body>
         <div id="map" style="width:700px; height:500px;"></div>
     </body>
 </html>

--- a/googlemap.html
+++ b/googlemap.html
@@ -15,6 +15,7 @@
 
         <script type="module">
             import {default as HeatCanvas} from './heatcanvas.js';
+            import {default as HeatCanvasOverlayView} from './heatcanvas-googlemaps.js';
 
             (function init() {
                 var latlng = new google.maps.LatLng(37, 104.2);

--- a/heatcanvas-baidumap.js
+++ b/heatcanvas-baidumap.js
@@ -20,8 +20,9 @@
  * SOFTWARE.
  */
 
+import {default as HeatCanvas} from "./heatcanvas.js";
 
-function HeatCanvasBaiduLayer(map,options){
+export default function HeatCanvasBaiduLayer(map,options){
     options = options || {};
     this._map = map;
     this.heatmap = null;
@@ -33,56 +34,55 @@ function HeatCanvasBaiduLayer(map,options){
     var self = this;
     this._map.addEventListener('dragend',function(){self.draw();});
     this._map.addEventListener('dbclick',function(){self.draw();});
-    }
+}
 
 HeatCanvasBaiduLayer.prototype= new BMap.Overlay();
 
 HeatCanvasBaiduLayer.prototype.initialize = function(map) {
-     var container = document.createElement("div");
-     var size =this._map.getSize();
-     container.style.cssText = "position:absolute;top:0;left:0;border:0";
-     container.style.width  = "100%";
-     container.style.height = "100%";
-    
-     var canvas = document.createElement("canvas");
-     canvas.style.width  = size.width + 'px';
-     canvas.style.height = size.height + 'px';
-     canvas.width = size.width;
-     canvas.height= size.height;
-     canvas.style.opacity = this.opacity;
-     container.appendChild(canvas);
+    var container = document.createElement("div");
+    var size =this._map.getSize();
+    container.style.cssText = "position:absolute;top:0;left:0;border:0";
+    container.style.width  = "100%";
+    container.style.height = "100%";
 
-     this.heatmap = new HeatCanvas(canvas);
-     var panes = this._map.getPanes();
-     panes.markerPane.appendChild(container);
-     this._div = container;
+    var canvas = document.createElement("canvas");
+    canvas.style.width  = size.width + 'px';
+    canvas.style.height = size.height + 'px';
+    canvas.width = size.width;
+    canvas.height= size.height;
+    canvas.style.opacity = this.opacity;
+    container.appendChild(canvas);
+
+    this.heatmap = new HeatCanvas(canvas);
+    var panes = this._map.getPanes();
+    panes.markerPane.appendChild(container);
+    this._div = container;
 }
 
 HeatCanvasBaiduLayer.prototype.pushData = function (lat, lon,value) {
-     this.data.push({"lon":lon, "lat": lat, "v": value});
+    this.data.push({"lon":lon, "lat": lat, "v": value});
 }
 
 HeatCanvasBaiduLayer.prototype.draw = function() {
-     var div = this._div;
-     var size = this._map.getSize();
-     var sw = this._map.pointToOverlayPixel(this._map.getBounds().getSouthWest());
-     var ne = this._map.pointToOverlayPixel(this._map.getBounds().getNorthEast());
-     var center= this._map.pointToOverlayPixel(this._map.getCenter());
-     div.style.left = sw.x+'px';
-     div.style.top  = ne.y+'px';
-     div.style.width = size.width+'px';
-     div.style.height = size.height +'px';
-     this.heatmap.clear();
-     if(this.data.length>0) {
+    var div = this._div;
+    var size = this._map.getSize();
+    var sw = this._map.pointToOverlayPixel(this._map.getBounds().getSouthWest());
+    var ne = this._map.pointToOverlayPixel(this._map.getBounds().getNorthEast());
+    var center= this._map.pointToOverlayPixel(this._map.getCenter());
+    div.style.left = sw.x+'px';
+    div.style.top  = ne.y+'px';
+    div.style.width = size.width+'px';
+    div.style.height = size.height +'px';
+    this.heatmap.clear();
+    if(this.data.length>0) {
         for(var i=0 , l=this.data.length;i<l;i++) {
-            latlon = new  BMap.Point(this.data[i].lat, this.data[i].lon);
-            localXY = this._map.pointToOverlayPixel(latlon);
+            var latlon = new  BMap.Point(this.data[i].lat, this.data[i].lon);
+            var localXY = this._map.pointToOverlayPixel(latlon);
             this.heatmap.push(
-                    Math.floor(localXY.x-sw.x),
-                    Math.floor(localXY.y-ne.y),
-                    this.data[i].v);
-            }
+                Math.floor(localXY.x-sw.x),
+                Math.floor(localXY.y-ne.y),
+                this.data[i].v);
         }
-        this.heatmap.render(this.step, this.degree, this.colorscheme);
     }
-
+    this.heatmap.render(this.step, this.degree, this.colorscheme);
+}

--- a/heatcanvas-googlemaps.js
+++ b/heatcanvas-googlemaps.js
@@ -21,7 +21,9 @@
  * SOFTWARE.
  */
 
-function HeatCanvasOverlayView(map, options){
+import {default as HeatCanvas} from './heatcanvas.js';
+
+export default function HeatCanvasOverlayView(map, options){
     options = options || {};
     this.setMap(map);
     this.heatmap = null;
@@ -56,7 +58,7 @@ HeatCanvasOverlayView.prototype.onAdd = function(){
     container.appendChild(canvas);
 
     this.heatmap = new HeatCanvas(canvas);
-    
+
     var panes = this.getPanes();
     panes.overlayLayer.appendChild(container);
     this._div = container;
@@ -85,12 +87,11 @@ HeatCanvasOverlayView.prototype.draw = function() {
             latlon = new google.maps.LatLng(this.data[i].lat, this.data[i].lon);
             localXY = proj.fromLatLngToContainerPixel(latlon);
             this.heatmap.push(
-                    Math.floor(localXY.x), 
-                    Math.floor(localXY.y), 
-                    this.data[i].v);
+                Math.floor(localXY.x),
+                Math.floor(localXY.y),
+                this.data[i].v);
         }
 
         this.heatmap.render(this.step, this.degree, this.colorscheme);
     }
 }
-

--- a/heatcanvas-googlemaps.js
+++ b/heatcanvas-googlemaps.js
@@ -84,8 +84,8 @@ HeatCanvasOverlayView.prototype.draw = function() {
     this.heatmap.clear();
     if (this.data.length > 0) {
         for (var i=0, l=this.data.length; i<l; i++) {
-            latlon = new google.maps.LatLng(this.data[i].lat, this.data[i].lon);
-            localXY = proj.fromLatLngToContainerPixel(latlon);
+            var latlon = new google.maps.LatLng(this.data[i].lat, this.data[i].lon);
+            var localXY = proj.fromLatLngToContainerPixel(latlon);
             this.heatmap.push(
                 Math.floor(localXY.x),
                 Math.floor(localXY.y),

--- a/heatcanvas-leaflet.js
+++ b/heatcanvas-leaflet.js
@@ -20,11 +20,15 @@
  * SOFTWARE.
  */
 
-L.TileLayer.HeatCanvas = L.Class.extend({
+import {default as HeatCanvas} from './heatcanvas.js';
+
+L.TileLayer.HeatCanvas = L.Layer.extend({
 
     initialize: function(options, heatCanvasOptions){
+        L.Util.setOptions(this, options);
+
         this.heatCanvasOptions = heatCanvasOptions;
-        this.data= [];
+        this.data = [];
         this._onRenderingStart = null;
         this._onRenderingEnd = null;
     },
@@ -40,77 +44,103 @@ L.TileLayer.HeatCanvas = L.Class.extend({
     onAdd: function(map) {
         this.map = map;
         this._initHeatCanvas(this.map, this.heatCanvasOptions);
-        map.on("viewreset", this._redraw, this);
         map.on("moveend", this._redraw, this);
-        map.on("dragend", this._redraw, this);
-        map.on("zoomend", this._redraw, this);
+        map.on("resize", this._resize, this);
         this._redraw();
     },
 
     onRemove: function(map) {
         map.getPanes().overlayPane.removeChild(this._div);
-        map.off("viewreset", this._redraw, this);
+        map.off("resize", this._resize, this);
         map.off("moveend", this._redraw, this);
-        map.off("dragend", this._redraw, this);
-        map.off("zoomend", this._redraw, this);
     },
 
-    _initHeatCanvas: function(map, options){
-        options = options || {};                        
+    _initHeatCanvas: function(map, options) {
+        options = options || {};
         this._step = options.step || 1;
         this._degree = options.degree || HeatCanvas.LINEAR;
         this._opacity = options.opacity || 0.6;
+        this._zIndex = options.zIndex || null;
         this._colorscheme = options.colorscheme || null;
 
+        var mapSize = this.map.getSize();
         var container = L.DomUtil.create('div', 'leaflet-heatmap-container');
         container.style.position = 'absolute';
-        container.style.width = this.map.getSize().x+"px";
-        container.style.height = this.map.getSize().y+"px";
+        container.style.width = mapSize.x+"px";
+        container.style.height = mapSize.y+"px";
+        if (this._zIndex != null) {
+            container.style.zIndex = this._zIndex;
+        }
 
         var canv = document.createElement("canvas");
-        canv.style.width = this.map.getSize().x+"px";
-        canv.style.height = this.map.getSize().y+"px";
-        canv.width = parseInt(canv.style.width);
-        canv.height = parseInt(canv.style.height);
+        canv.width = mapSize.x;
+        canv.height = mapSize.y;
+        canv.style.width = canv.width+"px";
+        canv.style.height = canv.height+"px";
         canv.style.opacity = this._opacity;
         container.appendChild(canv);
 
         this.heatmap = new HeatCanvas(canv);
         this.heatmap.onRenderingStart = this._onRenderingStart;
         this.heatmap.onRenderingEnd = this._onRenderingEnd;
+        this.heatmap.bgcolor = options.bgcolor || null;
         this._div = container;
         this.map.getPanes().overlayPane.appendChild(this._div);
     },
 
     pushData: function(lat, lon, value) {
-        this.data.push({"lon":lon, "lat":lat, "v":value});
+        this.data.push({"lat":lat, "lon":lon, "v":value});
     },
-    
+
     _resetCanvasPosition: function() {
         var bounds = this.map.getBounds();
         var topLeft = this.map.latLngToLayerPoint(bounds.getNorthWest());
-        //topLeft = this.map.layerPointToContainerPoint(topLeft);
-
         L.DomUtil.setPosition(this._div, topLeft);
     },
 
     _redraw: function() {
         this._resetCanvasPosition();
         this.heatmap.clear();
-        if (this.data.length > 0) {
+        var sz = this.map.getSize();
+        if (this.data.length > 0 && sz.x > 0 && sz.y > 0) {
             for (var i=0, l=this.data.length; i<l; i++) {
                 var lonlat = new L.LatLng(this.data[i].lat, this.data[i].lon);
                 var localXY = this.map.latLngToLayerPoint(lonlat);
                 localXY = this.map.layerPointToContainerPoint(localXY);
                 this.heatmap.push(
-                        Math.floor(localXY.x), 
-                        Math.floor(localXY.y), 
-                        this.data[i].v);
+                    Math.floor(localXY.x),
+                    Math.floor(localXY.y),
+                    this.data[i].v);
             }
 
             this.heatmap.render(this._step, this._degree, this._colorscheme);
         }
         return this;
+    },
+
+    _resize: function() {
+        var sz = this.map.getSize();
+
+        this._div.style.width = sz.x + "px";
+        this._div.style.height = sz.y + "px";
+        this.heatmap.resize(sz.x, sz.y);
+    },
+
+    clear: function() {
+        if (this.heatmap) {
+            this.heatmap.clear();
+        }
+        this.data = [];
+    },
+
+    redraw: function() {
+        this._redraw();
     }
 
 });
+
+L.TileLayer.heatcanvas = function (options, heatCanvasOptions) {
+    return new L.TileLayer.HeatCanvas(options, heatCanvasOptions);
+};
+
+export default L.TileLayer.heatcanvas;

--- a/heatcanvas-openlayers.js
+++ b/heatcanvas-openlayers.js
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+import {default as HeatCanvas} from "./heatcanvas";
+
 OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
 
     isBaseLayer: false,
@@ -28,7 +30,7 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
 
     initialize: function(name, map, options, heatCanvasOptions){
         OpenLayers.Layer.prototype.initialize.apply(this, [name, options]);
-        
+
         this.setMap(map);
         this.heatCanvasOptions = heatCanvasOptions;
         this.initHeatCanvas(this.map, this.heatCanvasOptions);
@@ -36,7 +38,7 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
     },
 
     initHeatCanvas: function(map, options){
-        options = options || {};                        
+        options = options || {};
         this._step = options.step || 1;
         this._degree = options.degree || HeatCanvas.LINEAR;
         this._opacity = options.opacity || 0.6;
@@ -59,7 +61,7 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
         this.div.appendChild(container);
         this._div = container;
     },
-    
+
     onMapResize: function() {
         var size = this.map.getSize();
         this.heatmap.resize( size.w, size.h );
@@ -68,7 +70,7 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
     pushData: function(lat, lon, value) {
         this.data.push({"lon":lon, "lat":lat, "v":value});
     },
-    
+
     _resetCanvasPosition: function() {
         var extent = this.map.getExtent();
         var nw = new OpenLayers.LonLat(extent.left, extent.top);
@@ -87,9 +89,9 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
                 lonlat = lonlat.transform(this.map.displayProjection, this.map.getProjectionObject())
                 var localXY = this.map.getViewPortPxFromLonLat(lonlat);
                 this.heatmap.push(
-                        Math.floor(localXY.x), 
-                        Math.floor(localXY.y), 
-                        this.data[i].v);
+                    Math.floor(localXY.x),
+                    Math.floor(localXY.y),
+                    this.data[i].v);
             }
 
             this.heatmap.render(this._step, this._degree, this._colorscheme);
@@ -102,3 +104,5 @@ OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
 
     CLASS_NAME: "OpenLayers.Layer.HeatCanvas"
 });
+
+export default OpenLayers.Layer.HeatCanvas;

--- a/heatcanvas-openlayers.js
+++ b/heatcanvas-openlayers.js
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-import {default as HeatCanvas} from "./heatcanvas";
+import {default as HeatCanvas} from "./heatcanvas.js";
 
 OpenLayers.Layer.HeatCanvas = OpenLayers.Class(OpenLayers.Layer, {
 

--- a/heatcanvas-worker.js
+++ b/heatcanvas-worker.js
@@ -24,44 +24,47 @@ onmessage = function(e){
 }
 
 function calc(params) {
-    value = params.value || {};
-    degree = params.degree || 1;
+    var value = params.value || {};
+    var degree = params.degree || 1;
+    var step = params.step || 1;
 
-    for(var pos in params.data){
-        var data = params.data[pos];
-        var radius = Math.floor(Math.pow((data / params.step), 1/degree));
-        
+    var deg2 = degree / 2;
+    for (var pos in params.data) {
+        var data = params.data[pos] / step;       // we don't need absolute values, and this allows us to get rid of many step*pow(...)
+        var radius = Math.floor(Math.pow(data, 1/degree));
+        var radiusSq = Math.pow(radius, 2);
+
         var x = Math.floor(pos%params.width);
         var y = Math.floor(pos/params.width);
-        
-        // calculate point x.y 
-        for(var scanx=x-radius; scanx<x+radius; scanx+=1){            
+
+        // calculate point x.y
+        for(var scanx=x-radius; scanx<x+radius; scanx+=1){
             // out of extend
             if(scanx<0 || scanx>params.width){
                 continue;
             }
             for(var scany=y-radius; scany<y+radius; scany+=1){
-            
+
                 if(scany<0 || scany>params.height){
                     continue;
-                }                  
-                
-                var dist = Math.sqrt(Math.pow((scanx-x), 2)+Math.pow((scany-y), 2));
-                if(dist > radius){
+                }
+
+                var distSq = Math.pow((scanx-x), 2) + Math.pow((scany-y), 2);
+                if (distSq > radiusSq){
                     continue;
                 } else {
-                    var v = data - params.step * Math.pow(dist, degree);
-                    
+                    var v = data - Math.pow(distSq, deg2);
+
                     var id = scanx+scany*params.width ;
-                
+
                     if(value[id]){
-                        value[id] = value[id] + v;           
+                        value[id] = value[id] + v;
                     } else {
                         value[id] = v;
                     }
                 }
             }
-        }        
+        }
     }
-    postMessage({'value': value});
+    postMessage({'value': value, 'width': params.width, 'height': params.height});
 }

--- a/index.html
+++ b/index.html
@@ -1,8 +1,7 @@
 <html>
   <head>
     <title>HeatCanvas Demo</title>
-    <script type="text/javascript" src="heatcanvas.js"></script>
-    
+
     <style type="text/css">
         #canv{
             border:1px #CCC solid;
@@ -21,11 +20,13 @@
     </p>
     <p>Data Added: <span id="info">No Data.</span></p>
     
-    <script type="text/javascript">
+    <script type="module">
+        import {default as HeatCanvas} from './heatcanvas.js';
+
         // create heatmap object
-        heatmap = new HeatCanvas("canv");
-        heatmap.onRenderingStart = function(){document.getElementById('status').innerHTML = 'rendering...'}
-        heatmap.onRenderingEnd = function(){document.getElementById('status').innerHTML = 'ready'}
+        var heatmap = new HeatCanvas("canv");
+        heatmap.onRenderingStart = function(){document.getElementById('status').innerHTML = 'rendering...'};
+        heatmap.onRenderingEnd = function(){document.getElementById('status').innerHTML = 'ready'};
 
         /* add data interactively */
         document.getElementById("canv").onclick = function(e){

--- a/index.html
+++ b/index.html
@@ -13,9 +13,9 @@
     <p>Click on the canvas below to add some data, then hit the "HEAT MAP!" button. Refresh to reset. </p>
     <div><canvas width="400" height="300" id="canv"></canvas></div>
     <p>Value for each click: <input type="text" value="20" id="pressure" />
-    <button onclick="genData();">Generate Random Data</button>
-    <button onclick="render();">HEAT MAP!</button>
-    <button onclick="reset();">Reset</button>
+    <button id="genData">Generate Random Data</button>
+    <button id="render">HEAT MAP!</button>
+    <button id="reset">Reset</button>
     <span id="status"></span>
     </p>
     <p>Data Added: <span id="info">No Data.</span></p>
@@ -62,6 +62,10 @@
             // you can render the map with custom colors
             heatmap.render(1, null, null);
         }
+
+        document.getElementById("genData").onclick = genData;
+        document.getElementById("render").onclick = render;
+        document.getElementById("reset").onclick = reset;
     </script>
     <p>Watch the source code on <a href="https://github.com/sunng87/canvas-heatmap">github</a>. </p>
     <p><a href="googlemap.html">HeatCanvas on Google Maps.</a> and <a href="openstreetmap.html">OpenStreetMap</a></p>

--- a/leaflet.html
+++ b/leaflet.html
@@ -18,8 +18,10 @@
             }
         </style>
 
-        <script type="text/javascript">
-            function init(){
+        <script type="module">
+            import {default as HeatCanvas} from './heatcanvas.js';
+
+            (function init(){
               var map = new L.Map("map");
               var markerLayers = new L.LayerGroup();
                 var cloudmadeUrl = 'http://{s}.tile.cloudmade.com/8ee2a50541944fb9bcedded5165f09d9/997/256/{z}/{x}/{y}.png',
@@ -51,11 +53,12 @@
                 map.addLayer(markerLayers);
                 L.control.layers({"heatmap":heatmap, "markers": markerLayers}).addTo(map);
 
-            }
+            })();
+
         </script>
     </head>
 
-    <body onload="init();">
+    <body>
         <div>
             <h1>Heatcanvas for Leaflet</h1>
             <p>This is

--- a/leaflet.html
+++ b/leaflet.html
@@ -30,7 +30,7 @@
                 map.setView(new L.LatLng(40, -90), 3);                
                 var heatmap = new
                 L.TileLayer.HeatCanvas({},{'step':0.5,
-                'degree':HeatCanvas.LINEAR, 'opacity':0.7});
+                'degree':1, 'opacity':0.7});
                 heatmap.onRenderingStart(function(){
                     document.getElementById("status").innerHTML =
                 'rendering';  

--- a/leaflet.html
+++ b/leaflet.html
@@ -4,10 +4,14 @@
         <meta charset="utf8" />
         <title>HeatCanvas on Leaflet</title>
 
-        <link rel="stylesheet" href="http://leaflet.cloudmade.com/dist/leaflet.css" />
-        <script src="http://leaflet.cloudmade.com/dist/leaflet.js" type="text/javascript"></script>
-        <script type="text/javascript" src="heatcanvas.js"></script>
-        <script type="text/javascript" src="heatcanvas-leaflet.js"></script>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+              integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+              crossorigin=""/>
+        <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+                integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+                crossorigin=""></script>
+        <script type="module" src="heatcanvas.js"></script>
+        <script type="module" src="heatcanvas-leaflet.js"></script>
 
         <style type="text/css">
             #map{
@@ -57,7 +61,7 @@
             <p>This is
             a <a href="https://github.com/sunng87/heatcanvas">heatcanvas</a>
             layer
-            for <a href="http://leaflet.cloudmade.com/">leaflet</a>
+            for <a href="https://leafletjs.com/">leaflet</a>
             map api.</p>
             <p id="status"></p>
         </div>

--- a/leaflet.html
+++ b/leaflet.html
@@ -32,7 +32,7 @@
                 map.setView(new L.LatLng(40, -90), 3);                
                 var heatmap = new
                 L.TileLayer.HeatCanvas({},{'step':0.5,
-                'degree':1, 'opacity':0.7});
+                'degree':HeatCanvas.LINEAR, 'opacity':0.7});
                 heatmap.onRenderingStart(function(){
                     document.getElementById("status").innerHTML =
                 'rendering';  

--- a/openstreetmap.html
+++ b/openstreetmap.html
@@ -16,6 +16,8 @@
 
         <script type="module">
             import {default as HeatCanvas} from './heatcanvas.js';
+            import {default as HCOL} from './heatcanvas-openlayers.js';
+
 
             var map, layer;
             (function init(){

--- a/openstreetmap.html
+++ b/openstreetmap.html
@@ -4,8 +4,8 @@
         <meta charset="utf8" />
         <title>OpenStreetMap Heatmap</title>
 
-        <script src="http://openstreetmap.org/openlayers/OpenLayers.js" type="text/javascript"></script>
-        <script src="http://openstreetmap.org/openlayers/OpenStreetMap.js" type="text/javascript"></script>
+        <script src="https://openstreetmap.org/openlayers/OpenLayers.js" type="text/javascript"></script>
+        <script src="https://openstreetmap.org/openlayers/OpenStreetMap.js" type="text/javascript"></script>
         <script type="module" src="heatcanvas.js"></script>
         <script type="module" src="heatcanvas-openlayers.js"></script>
 
@@ -16,7 +16,7 @@
 
         <script type="module">
             import {default as HeatCanvas} from './heatcanvas.js';
-            
+
             var map, layer;
             (function init(){
                 map = new OpenLayers.Map ("map", {

--- a/openstreetmap.html
+++ b/openstreetmap.html
@@ -6,17 +6,19 @@
 
         <script src="http://openstreetmap.org/openlayers/OpenLayers.js" type="text/javascript"></script>
         <script src="http://openstreetmap.org/openlayers/OpenStreetMap.js" type="text/javascript"></script>
-        <script type="text/javascript" src="heatcanvas.js"></script>
-        <script type="text/javascript" src="heatcanvas-openlayers.js"></script>
+        <script type="module" src="heatcanvas.js"></script>
+        <script type="module" src="heatcanvas-openlayers.js"></script>
 
         <style type="text/css">
             #map{
             }
         </style>
 
-        <script type="text/javascript">
+        <script type="module">
+            import {default as HeatCanvas} from './heatcanvas.js';
+            
             var map, layer;
-            function init(){
+            (function init(){
                 map = new OpenLayers.Map ("map", {
                   controls: [
                       new OpenLayers.Control.Attribution(),
@@ -57,12 +59,12 @@
                     heatmap.pushData(data[i][0], data[i][1], data[i][2]);
                 }
                 map.addLayer(heatmap);
-            }
+            })();
             window.map = map;
         </script>
     </head>
 
-    <body onload="init();">
+    <body>
         <div id="map" style="width:850px; height:500px;"></div>
         <div>This is the heat map represents visitor distribution of my blog on June 3 and June 4. It's based on my heat map library <a href="http://github.com/sunng87/heatcanvas/"><em>Heat Canvas</em></a> OpenLayers extension. You can zoom in to see local detail. 
             <a href="http://sunng.info/blog/2011/06/openlayers-extension-for-heatcanvas/">Here is my blog post</a> describes the usage. You can also get involved by ctrl+u.</div>

--- a/openstreetmap.html
+++ b/openstreetmap.html
@@ -4,8 +4,8 @@
         <meta charset="utf8" />
         <title>OpenStreetMap Heatmap</title>
 
-        <script src="https://openstreetmap.org/openlayers/OpenLayers.js" type="text/javascript"></script>
-        <script src="https://openstreetmap.org/openlayers/OpenStreetMap.js" type="text/javascript"></script>
+        <script src="https://www.openstreetmap.org/openlayers/OpenLayers.js" type="text/javascript"></script>
+        <script src="https://www.openstreetmap.org/openlayers/OpenStreetMap.js" type="text/javascript"></script>
         <script type="module" src="heatcanvas.js"></script>
         <script type="module" src="heatcanvas-openlayers.js"></script>
 
@@ -16,8 +16,6 @@
 
         <script type="module">
             import {default as HeatCanvas} from './heatcanvas.js';
-            import {default as HCOL} from './heatcanvas-openlayers.js';
-
 
             var map, layer;
             (function init(){


### PR DESCRIPTION
Upgrade leaflet demo to support lleaflet 1.7.1
#32 

Do not understand, why i had to replace 
import {default as HeatCanvas} from './heatcanvas';
with
import {default as HeatCanvas} from './heatcanvas.js';
in all 'heatcanvas-xxx.js' modules :(
Or how it works without these replacements.